### PR TITLE
Add support for multi leaderboards to repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,19 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
-			<version>1.18.10</version>
+			<version>1.18.24</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>1.4.200</version>
 		</dependency>
-
+		<dependency>
+		    <groupId>org.springdoc</groupId>
+		    <artifactId>springdoc-openapi-core</artifactId>
+		    <version>1.1.49</version>
+		</dependency>
+	
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardEntryEntity.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardEntryEntity.java
@@ -1,11 +1,18 @@
 package com.gloot.springbootcodetest.leaderboard;
 
 import java.util.UUID;
+
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsEntryEntity;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,14 +25,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeaderboardEntryEntity {
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private UUID uuid;
-  private String nick;
-  private Integer score;
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private UUID uuid;
+	private String nick;
+	private Integer score;
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "board_id")
+	private LeaderboardsEntryEntity leaderboard;
 
-  public LeaderboardEntryEntity (String nick, Integer score) {
-    this.nick = nick;
-    this.score = score;
-  }
+	public LeaderboardEntryEntity(String nick, Integer score, LeaderboardsEntryEntity leaderboard) {
+		this.nick = nick;
+		this.score = score;
+		this.leaderboard = leaderboard;
+	}
+
 }

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
@@ -6,41 +6,44 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
 public class LeaderboardService {
+	private static final String DEFAULT_BOARD = "DEFAULT";
 
-  private final LeaderboardRepository repository;
+	private final LeaderboardRepository repository;
 
-  public List<LeaderboardEntryDto> getListOfAllLeaderboardEntriesAsDTO() {
-    List <LeaderboardEntryEntity> allEntries = repository.findAll();
-    Collections.sort(allEntries, new Comparator<LeaderboardEntryEntity>(){
-      public int compare(LeaderboardEntryEntity e1, LeaderboardEntryEntity e2) {
-        return e2.getScore() - e1.getScore();
-      }
-    });
+	public List<LeaderboardEntryDto> getListOfAllLeaderboardEntriesAsDTO() {
+		List<LeaderboardEntryEntity> allEntries = repository.findAll().stream().filter(e -> DEFAULT_BOARD.equals(e.getLeaderboard().getName())).collect(Collectors.toList());
+		Collections.sort(allEntries, new Comparator<LeaderboardEntryEntity>() {
+			public int compare(LeaderboardEntryEntity e1, LeaderboardEntryEntity e2) {
+				return e2.getScore() - e1.getScore();
+			}
+		});
 
-    LeaderboardEntryEntity[] allEntriesAsEntities = allEntries.toArray(new LeaderboardEntryEntity[]{});
-    LeaderboardEntryDto[] dtoObjects = new LeaderboardEntryDto[allEntriesAsEntities.length];
+		LeaderboardEntryEntity[] allEntriesAsEntities = allEntries.toArray(new LeaderboardEntryEntity[] {});
+		LeaderboardEntryDto[] dtoObjects = new LeaderboardEntryDto[allEntriesAsEntities.length];
 
-    for(int i=allEntriesAsEntities.length-1;i>=0;i--) {
-      dtoObjects[i] = mapToDto(i+1, allEntriesAsEntities[i]);
-    }
+		for (int i = allEntriesAsEntities.length - 1; i >= 0; i--) {
+			dtoObjects[i] = mapToDto(i + 1, allEntriesAsEntities[i]);
+		}
 
-    List<LeaderboardEntryDto> leaderboardEntryDtos = new ArrayList<>();
-    for(int j=dtoObjects.length-1;j>=0;j--) {
-      leaderboardEntryDtos.add(dtoObjects[j]);
-    }
+		List<LeaderboardEntryDto> leaderboardEntryDtos = new ArrayList<>();
+		for (int j = dtoObjects.length - 1; j >= 0; j--) {
+			leaderboardEntryDtos.add(dtoObjects[j]);
+		}
 
-    Collections.sort(leaderboardEntryDtos, new Comparator<LeaderboardEntryDto>(){
-      public int compare(LeaderboardEntryDto e1, LeaderboardEntryDto e2) {
-        return e1.getPosition() - e2.getPosition();
-      }
-    });
+		Collections.sort(leaderboardEntryDtos, new Comparator<LeaderboardEntryDto>() {
+			public int compare(LeaderboardEntryDto e1, LeaderboardEntryDto e2) {
+				return e1.getPosition() - e2.getPosition();
+			}
+		});
 
-    return leaderboardEntryDtos;
-  }
+		return leaderboardEntryDtos;
+	}
 }

--- a/src/main/java/com/gloot/springbootcodetest/leaderboards/LeaderboardsEntryEntity.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboards/LeaderboardsEntryEntity.java
@@ -1,0 +1,40 @@
+package com.gloot.springbootcodetest.leaderboards;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import com.gloot.springbootcodetest.leaderboard.LeaderboardEntryEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "leaderboards")
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeaderboardsEntryEntity {
+	  @Id
+	  @GeneratedValue(strategy = GenerationType.AUTO)
+	  private UUID uuid;
+	  private String name;
+	  @OneToMany(mappedBy = "leaderboard", fetch = FetchType.LAZY)
+	  @EqualsAndHashCode.Exclude private List<LeaderboardEntryEntity> ranks;
+	
+	  public LeaderboardsEntryEntity(String name) {
+		this.name = name;
+	}
+  
+}

--- a/src/main/java/com/gloot/springbootcodetest/leaderboards/LeaderboardsRepository.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboards/LeaderboardsRepository.java
@@ -1,0 +1,10 @@
+package com.gloot.springbootcodetest.leaderboards;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeaderboardsRepository extends JpaRepository<LeaderboardsEntryEntity, UUID> {
+	LeaderboardsEntryEntity findByName(String name);
+}

--- a/src/main/resources/db/migration/V3__add_multi_boards_support.sql
+++ b/src/main/resources/db/migration/V3__add_multi_boards_support.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS leaderboards (
+    uuid UUID DEFAULT RANDOM_UUID() NOT NULL PRIMARY KEY,
+    name VARCHAR(20) NOT NULL UNIQUE
+);
+
+ALTER TABLE leaderboard ADD board_id UUID;
+
+INSERT INTO leaderboards(name) VALUES ('DEFAULT');
+
+UPDATE leaderboard SET board_id = (SELECT uuid FROM leaderboards WHERE name = 'DEFAULT');
+
+alter table leaderboard alter column board_id UUID NOT NULL;

--- a/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardControllerTest.java
+++ b/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardControllerTest.java
@@ -7,6 +7,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.gloot.springbootcodetest.SpringBootComponentTest;
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsEntryEntity;
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsRepository;
+
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +19,12 @@ public class LeaderboardControllerTest extends SpringBootComponentTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired LeaderboardRepository repository;
+  @Autowired LeaderboardsRepository leaderboardsRepository;
 
   @Test
   void getLeaderboardTest() throws Exception {
-    LeaderboardEntryEntity entity = new LeaderboardEntryEntity("g-looter", 100);
+	LeaderboardsEntryEntity board = leaderboardsRepository.findByName("DEFAULT");
+    LeaderboardEntryEntity entity = new LeaderboardEntryEntity("g-looter", 100, board);
     repository.saveAll(List.of(entity));
 
     mockMvc.perform(get("/api/v1/leaderboard"))

--- a/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardRepositoryTest.java
+++ b/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardRepositoryTest.java
@@ -4,16 +4,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.gloot.springbootcodetest.SpringBootComponentTest;
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsEntryEntity;
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsRepository;
+
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class LeaderboardRepositoryTest extends SpringBootComponentTest {
   @Autowired LeaderboardRepository repository;
+  @Autowired LeaderboardsRepository leaderboardsRepository;
 
   @Test
   void saveAndRetrieve() {
-    LeaderboardEntryEntity entity = new LeaderboardEntryEntity("g-looter", 100);
+	LeaderboardsEntryEntity board = leaderboardsRepository.findByName("DEFAULT");
+    LeaderboardEntryEntity entity = new LeaderboardEntryEntity("g-looter", 100, board);
     repository.saveAll(List.of(entity));
     LeaderboardEntryEntity fromRepository = repository.findById(entity.getUuid()).get();
     assertThat(fromRepository, is(entity));

--- a/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardServiceTest.java
+++ b/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardServiceTest.java
@@ -3,6 +3,9 @@ package com.gloot.springbootcodetest.leaderboard;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.gloot.springbootcodetest.SpringBootComponentTest;
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsEntryEntity;
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsRepository;
+
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,12 +14,14 @@ public class LeaderboardServiceTest extends SpringBootComponentTest {
 
   @Autowired LeaderboardRepository repository;
   @Autowired LeaderboardService service;
+  @Autowired LeaderboardsRepository leaderboardsRepository;
 
   @Test
   void getLeaderboard() {
+	LeaderboardsEntryEntity board = leaderboardsRepository.findByName("DEFAULT");
     List<LeaderboardEntryEntity> entities = List
-        .of(new LeaderboardEntryEntity("g-looter-2", 90),
-            new LeaderboardEntryEntity("g-looter-1", 100));
+        .of(new LeaderboardEntryEntity("g-looter-2", 90, board),
+            new LeaderboardEntryEntity("g-looter-1", 100, board));
     repository.saveAll(entities);
 
     List<LeaderboardEntryDto> leaderboard = service


### PR DESCRIPTION
Add a new `leaderboards` entity to allow the user to challenge in different ranking types. Each `leaderboards` entry has one or more `leaderboard` entries mapping the score (and the position) of a user for that specific ranking.
The current ranking will be assigned to a _DEFAULT_ `leaderboards`.

**List of Changes**

add `leaderboards` table and entity/repository 
update `leaderboard` entity
update `LeaderboardService  for backward compatibility fix unit tests

**Motivation and Context**

Overcome the current limit of "only one" ranking: with this PR the users could compete each other in different ranking type.

**How Has This Been Tested?**

unit test
